### PR TITLE
Add type definition for TypeScript

### DIFF
--- a/index.d.ts
+++ b/index.d.ts
@@ -1,0 +1,7 @@
+declare module "flyd-skip" {
+  interface Skip {
+    <T>(count: number, stream: flyd.Stream<T>): flyd.Stream<T>;
+  }
+  const _Skip: Skip;
+  export = _Skip;
+}


### PR DESCRIPTION
Thank you for providing this useful extension.
I made a TypeScript type definition file of this library for personal use. It would be useful to include `d.ts` in the repository for TypeScript users.

Feel free to request me changes.